### PR TITLE
Do not fail if $EDITOR contains spaces

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -65,16 +65,20 @@ def editor(initial_contents=None, filename=None, editor=None):
         is used.
 
       editor
-        The path to an editor to call.  If None, use editor.default_editor()
+        The path to an editor to call.  If None, use editor.default_editor().
+        If it is a str, it will be converted to a list splitting by spaces.
+        If it is a list, it will be kept as is.
     """
     editor = editor or default_editor()
+    if type(editor) is str:
+        editor = editor.split()
     if not filename:
         with tempfile.NamedTemporaryFile(mode='r+', suffix='.txt') as fp:
             if initial_contents is not None:
                 fp.write(initial_contents)
                 fp.flush()
 
-            subprocess.call([editor, fp.name])
+            subprocess.call(editor + [fp.name])
 
             fp.seek(0)
             return fp.read()
@@ -83,15 +87,15 @@ def editor(initial_contents=None, filename=None, editor=None):
     if initial_contents is not None:
         path.write_text(initial_contents)
 
-    subprocess.call([editor, filename])
+    subprocess.call(editor + [filename])
     return path.read_text()
 
 
 def default_editor():
     """
-    Return the default text editor.
+    Return the default text editor as a list of command arguments.
 
     This is the contents of the environment variable EDITOR, or  ``'vim'`` if
     that variable is not set or is empty.
     """
-    return os.environ.get('EDITOR', 'vim')
+    return os.environ.get('EDITOR', 'vim').split()


### PR DESCRIPTION
A common usage is `code --wait` to use VSCode as editor.

Before this patch, the library would fail with:

```python
>>> import editor
>>> editor.edit('hello')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/home/yajo/prodevel/copier/.venv/lib64/python3.8/site-packages/editor.py", line 101, in edit
    proc = subprocess.Popen(args, close_fds=True, stdout=stdout)
  File "/usr/lib64/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'code --wait'
>>> editor.__version__
'1.0.4'
```