### PR TITLE
use the fully resolved path

### DIFF
--- a/editor/__init__.py
+++ b/editor/__init__.py
@@ -90,7 +90,7 @@ def editor(
         if text is not None:
             path.write_text(text)
 
-        cmd = '{} {}'.format(editor, fname)
+        cmd = '{} "{}"'.format(editor, path.resolve())
         runs.call(cmd, **kwargs)
         return path.read_text()
 


### PR DESCRIPTION
On windows using the `fname` directly may result in corruped pathes, due to problems with `/` vs `\` and `\` needing to be escaped properly.

Using the resolved path via `pathlib` ensures this allways works proerly.


I also added quotation marks to make sure pathes containing spaces work properly (especially importand on windows as the `C:\Users\user name` directory can easiely contain spaces)
